### PR TITLE
Convert solution_file path to str

### DIFF
--- a/dozeloc.py
+++ b/dozeloc.py
@@ -100,7 +100,7 @@ class DozelocUI(ttk.Frame):
         self.grid_columnconfigure(1, weight=1)
         self.grid_columnconfigure(2, weight=1)
         self.grid_rowconfigure(3, weight=1)
-    
+
     def select(self, event):
         self.exercise_text.config(state="normal")
         ex = self.exdir / self.exercise_chooser.get()
@@ -375,7 +375,7 @@ def run_unittest(test_file, solution_file):
     if "PYTHONPATH" not in subenv:
         subenv["PYTHONPATH"] = str(solution_file.parent)
     else:
-        subenv["PYTHONPATH"] += ":" + (solution_file.parent)
+        subenv["PYTHONPATH"] += ":" + str(solution_file.parent)
     # using sys.executable ensures that we use same python for internal tests as for main program
     # set cwd to test directory in order to be able to read test files
     res = subprocess.run(


### PR DESCRIPTION
Could not load solution_file path when python path was already in subenv because it was not str:

Exception in Tkinter callback
Traceback (most recent call last):
  File "/Users/nineve/opt/miniconda3/lib/python3.9/tkinter/__init__.py", line 1892, in __call__
    return self.func(*args)
  File "/Users/nineve/Dropbox/dozeloc/dozeloc.py", line 123, in check
    text, code = run_unittest(t, sol)
  File "/Users/nineve/Dropbox/dozeloc/dozeloc.py", line 378, in run_unittest
    subenv["PYTHONPATH"] += ":" + (solution_file.parent)
TypeError: can only concatenate str (not "PosixPath") to str
